### PR TITLE
Does not audit hard deleted records for GDPR reason

### DIFF
--- a/src/AuditableObserver.php
+++ b/src/AuditableObserver.php
@@ -74,6 +74,9 @@ class AuditableObserver
      */
     public function deleted(Auditable $model)
     {
+        if ($model->isForceDeleting()) {
+            return null;
+        }
         Auditor::execute($model->setAuditEvent('deleted'));
     }
 


### PR DESCRIPTION
handles not adding a delete entry when a soft deleted mode is getting hard deleted